### PR TITLE
Set up Vite server proxy to backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,11 +4,11 @@ app.py
 This one file is all you need to start off with your FastAPI server!
 """
 
+import random
 from typing import Optional
 
 import uvicorn
 from fastapi import FastAPI, status
-
 
 # Initializing and setting configurations for your FastAPI application is one
 # of the first things you should do in your code.
@@ -54,7 +54,9 @@ def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 
-# TODO: Add POST route for demo
+@app.get("/get-random")
+def get_random_item():
+    return {"item_id": random.randint(0, 1000)}
 
 
 if __name__ == "__main__":

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
 import "./App.css";
@@ -12,6 +12,22 @@ With App.jsx, we can also define global variables and routes to store informatio
 */
 function App() {
 	const [count, setCount] = useState(0);
+	const [randomItem, setRandomItem] = useState(null);
+
+	async function getRandomItem() {
+		/*
+		You can access 
+		*/
+
+		const randInt = Math.floor(Math.random() * 1000);
+		const res = await fetch(`/api/items/${randInt}`);
+		const json = await res.json();
+		setRandomItem(json["item_id"]);
+	}
+
+	useEffect(() => {
+		getRandomItem();
+	}, []);
 
 	return (
 		<>
@@ -29,6 +45,9 @@ function App() {
 				<p>
 					Edit <code>src/App.jsx</code> and save to test HMR
 				</p>
+				{randomItem && (
+					<p>The item retrieved from the backend has an ID of {randomItem}</p>
+				)}
 			</div>
 			<p className="read-the-docs">Click on the Vite and React logos to learn more</p>
 		</>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,8 +25,7 @@ function App() {
 		where we display it in our JSX below.
 		*/
 
-		const randInt = Math.floor(Math.random() * 1000);
-		const res = await fetch(`/api/items/${randInt}`);
+		const res = await fetch(`/api/get-random`);
 		const json = await res.json();
 		setRandomItem(json["item_id"]);
 	}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,7 +16,13 @@ function App() {
 
 	async function getRandomItem() {
 		/*
-		You can access 
+		Because of the server proxy we set up in our Vite config, there's no
+		more need to specify the direct path to your backend! Simply provide
+		the path that your proxy is set up on and Vite will automatically
+		proxy these requests to the backend!
+
+		We query the backend and store its response into a state variable,
+		where we display it in our JSX below.
 		*/
 
 		const randInt = Math.floor(Math.random() * 1000);
@@ -45,6 +51,10 @@ function App() {
 				<p>
 					Edit <code>src/App.jsx</code> and save to test HMR
 				</p>
+
+				{/* Here's a trick you can use! If you want to render a JSX element only when a
+				state variable becomes not `null` (or by extension, not falsy), you can do a short
+				circuit operation with `&&`. */}
 				{randomItem && (
 					<p>The item retrieved from the backend has an ID of {randomItem}</p>
 				)}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,13 @@ import react from "@vitejs/plugin-react-swc";
 // https://vite.dev/config/
 export default defineConfig({
 	plugins: [react()],
+	server: {
+		proxy: {
+			"/api": {
+				target: "http://127.0.0.1:5000",
+				changeOrigin: true,
+				rewrite: (path) => path.replace(/^\/api/, ""),
+			},
+		},
+	},
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -17,6 +17,9 @@ export default defineConfig({
       then your request will be sent to `http://127.0.0.1:5000/` and you'll see
       the response returned by that route. (Note that that the URL in your
       browser's address will remain `http://localhost:5173/api`.)
+
+      If you've ever dealt with CORS errors when making requests from your
+      frontend to your backend, this will prevent those from happening!
       */
 			"/api": {
 				target: "http://127.0.0.1:5000",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,18 @@ export default defineConfig({
 	plugins: [react()],
 	server: {
 		proxy: {
+			/*
+      This block adds what's known as a proxy from your frontend to your
+      backend. Vite will take any requests that start with `/api` and forward
+      them to your backend. For example, with this setting in place, if you
+      try to access
+
+      `http://localhost:5173/api`
+
+      then your request will be sent to `http://127.0.0.1:5000/` and you'll see
+      the response returned by that route. (Note that that the URL in your
+      browser's address will remain `http://localhost:5173/api`.)
+      */
 			"/api": {
 				target: "http://127.0.0.1:5000",
 				changeOrigin: true,


### PR DESCRIPTION
Closes #9 by creating the server proxy and utilizing the item route specified in the backend to display an item with a random ID number. This is a pretty simple demo so it can be adjusted as long as it's able to convey an example usage of proxied requests.