### PR TITLE
Add support for client-side routing in both deployment systems

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -12,6 +12,11 @@ for hosting services that support building and deploying from a Dockerfile.
 Specifically, the React application bundle produced by Vite is copied to a public directory
 from which FastAPI serves static assets, i.e. the HTML, CSS, JS, and other images or data.
 
+The provided deployment configurations also support client-side routing libraries such as
+[React Router](https://reactrouter.com) or [TanStack Router](https://tanstack.com/router).
+This is done by having the frontend app served on all non-existent URL paths so that the
+single-page application (SPA) can resolve the appropriate view in the browser.
+
 ## Deploying on Render
 
 [Render](https://render.com) is a cloud application platform for hosting web services,

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -14,11 +14,11 @@ and any requests for the API paths will be sent to the API routes defined in the
 
 from pathlib import Path
 
-from fastapi import FastAPI
+import api
+from fastapi import FastAPI, Request
+from fastapi.exceptions import HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
-
-import api
 
 PUBLIC_DIRECTORY = Path("public")
 
@@ -38,4 +38,8 @@ async def root() -> FileResponse:
 # Make the public files (e.g. `index.html`) accessible on the server
 app.mount("/", StaticFiles(directory=PUBLIC_DIRECTORY), name="public")
 
+
 # TODO: add support for client-side routing
+@app.exception_handler(404)
+async def not_found(req: Request, exc: HTTPException) -> FileResponse:
+    return FileResponse(PUBLIC_DIRECTORY / "index.html")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -32,20 +32,23 @@ app.mount("/api/", api.app)
 
 @app.get("/")
 async def root() -> FileResponse:
-    """Provide the frontend on any other requested path."""
+    """Serve the frontend app on the root path."""
     return FileResponse(PUBLIC_DIRECTORY / "index.html")
 
 
-# Make the public files (e.g. `index.html`) accessible on the server
+# Make the public files (HTML, JS, CSS, etc.) accessible on the server
 app.mount("/", StaticFiles(directory=PUBLIC_DIRECTORY), name="public")
 
 
 @app.exception_handler(status.HTTP_404_NOT_FOUND)
 async def not_found(req: Request, exc: HTTPException) -> FileResponse:
     """
-    Redirect all other requests not directed to `/api/` or `/` back to the
-    frontend. The frontend is packaged and copied over to the Docker
-    container as part of the FastAPI application, so this `FileResponse`
-    will send the request back to the frontend.
+    Serve the frontend app for all other requests not directed to `/api/` or `/`.
+
+    This allows the single-page application to do client-side routing where the browser
+    process the URL path in the React App. Otherwise, users would see 404 Not Found when
+    navigating directly to a virtual path.
+
+    This should be removed if the frontend app does not handle different URL paths.
     """
     return FileResponse(PUBLIC_DIRECTORY / "index.html")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -15,7 +15,7 @@ and any requests for the API paths will be sent to the API routes defined in the
 from pathlib import Path
 
 import api
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, status
 from fastapi.exceptions import HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -40,6 +40,6 @@ app.mount("/", StaticFiles(directory=PUBLIC_DIRECTORY), name="public")
 
 
 # TODO: add support for client-side routing
-@app.exception_handler(404)
+@app.exception_handler(status.HTTP_404_NOT_FOUND)
 async def not_found(req: Request, exc: HTTPException) -> FileResponse:
     return FileResponse(PUBLIC_DIRECTORY / "index.html")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -14,11 +14,12 @@ and any requests for the API paths will be sent to the API routes defined in the
 
 from pathlib import Path
 
-import api
 from fastapi import FastAPI, Request, status
 from fastapi.exceptions import HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
+
+import api
 
 PUBLIC_DIRECTORY = Path("public")
 
@@ -39,7 +40,12 @@ async def root() -> FileResponse:
 app.mount("/", StaticFiles(directory=PUBLIC_DIRECTORY), name="public")
 
 
-# TODO: add support for client-side routing
 @app.exception_handler(status.HTTP_404_NOT_FOUND)
 async def not_found(req: Request, exc: HTTPException) -> FileResponse:
+    """
+    Redirect all other requests not directed to `/api/` or `/` back to the
+    frontend. The frontend is packaged and copied over to the Docker
+    container as part of the FastAPI application, so this `FileResponse`
+    will send the request back to the frontend.
+    """
     return FileResponse(PUBLIC_DIRECTORY / "index.html")

--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,17 @@
 {
-	"installCommand": "cd frontend && npm ci",
-	"buildCommand": "cd frontend && npm run build && cd .. && cp backend/requirements.txt .",
-	"outputDirectory": "frontend/dist",
-	"functions": {
-		"api/index.py": {
-			"excludeFiles": "{!(*.py),@(bin|frontend)/**,backend/{*,!(src)/**}}"
-		}
-	},
-	"rewrites": [{ "source": "/api/:path*", "destination": "/api/" }],
-	"env": {
-		"PYTHONPATH": "backend/src"
-	}
+  "installCommand": "cd frontend && npm ci",
+  "buildCommand": "cd frontend && npm run build && cd .. && cp backend/requirements.txt .",
+  "outputDirectory": "frontend/dist",
+  "functions": {
+    "api/index.py": {
+      "excludeFiles": "{!(*.py),@(bin|frontend)/**,backend/{*,!(src)/**}}"
+    }
+  },
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "/api/" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "env": {
+    "PYTHONPATH": "backend/src"
+  }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,17 +1,17 @@
 {
-  "installCommand": "cd frontend && npm ci",
-  "buildCommand": "cd frontend && npm run build && cd .. && cp backend/requirements.txt .",
-  "outputDirectory": "frontend/dist",
-  "functions": {
-    "api/index.py": {
-      "excludeFiles": "{!(*.py),@(bin|frontend)/**,backend/{*,!(src)/**}}"
-    }
-  },
-  "rewrites": [
-    { "source": "/api/:path*", "destination": "/api/" },
-    { "source": "/(.*)", "destination": "/index.html" }
-  ],
-  "env": {
-    "PYTHONPATH": "backend/src"
-  }
+	"installCommand": "cd frontend && npm ci",
+	"buildCommand": "cd frontend && npm run build && cd .. && cp backend/requirements.txt .",
+	"outputDirectory": "frontend/dist",
+	"functions": {
+		"api/index.py": {
+			"excludeFiles": "{!(*.py),@(bin|frontend)/**,backend/{*,!(src)/**}}"
+		}
+	},
+	"rewrites": [
+		{ "source": "/api/:path*", "destination": "/api/" },
+		{ "source": "/(.*)", "destination": "/index.html" }
+	],
+	"env": {
+		"PYTHONPATH": "backend/src"
+	}
 }


### PR DESCRIPTION
Closes #17 by creating an exception handler to redirect all requests to the container that result in a status code of 404 to `index.html` (the frontend application). This way, the frontend can handle the routing.

For deployment on Vercel, a [rewrite rule for SPA Fallback](https://vercel.com/docs/projects/project-configuration#legacy-spa-fallback) is added to `vercel.json`.

## Testing
1. Install `react-router-dom` in the frontend application.
2. Set up the default route `/` to the default component (e.g. `<App />`).
3. Create a new route and a new component associated with that route. For example, you can create the `/test` route that points to a new component `TestPage` in `TestPage.jsx`.
4. Build the Docker container locally with `docker build -t starter-pack .`
5. Run the container while exposing port 8000, the port that the Dockerfile runs the FastAPI application on: `docker run -p 8000:8000 starter-pack`.
6. Navigate to `http://localhost:8000/[new-route]` and observe the component associated with that route being rendered onto the screen.